### PR TITLE
ADD Ryzen 7 6800H Rembrandt CPU ID

### DIFF
--- a/zenergy.c
+++ b/zenergy.c
@@ -276,6 +276,7 @@ static const struct x86_cpu_id bit32_rapl_cpus[] = {
 	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x01, NULL),	/* Zen3 Threadripper */
 	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x21, NULL),	/* Zen3 */
 	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x50, NULL),	/* Cezanne */
+	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x44, NULL),	/* Rembrandt */
 	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x60, NULL),	/* Rembrandt */
 	{}
 };
@@ -373,6 +374,7 @@ static const struct x86_cpu_id cpu_ids[] __initconst = {
 	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x01, NULL),	/* Zen3 Threadripper */
 	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x21, NULL),	/* Zen3 */
 	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x50, NULL),	/* Cezanne */
+	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x44, NULL),	/* Rembrandt */
 	X86_MATCH_VENDOR_FAM_MODEL(AMD, 0x19, 0x60, NULL),	/* Rembrandt */
 	{}
 };


### PR DESCRIPTION
Dear @BoukeHaarsma23 
I have to note that while playing video games, I am getting some inconceivable CPU Power values: up to 160W...  so, I am taking this with a grain of salt,  since this is not an overclocked version like 6900HX or so...

Ryzen 7 6800H has a default TDP of 45W...  and worth mentioning that the games were played on discrete GPU RX 6700M which has its own power monitoring interface.
The device is 2022 Lenovo Legion 7 16ARHA7 (82UH)  AMD Advantage Edition laptop.

Worth mentioning that without this change the kernel module is not loaded as the CPU is not recognized (0x60 is not Rembrandt or Ryzen 7 6800H w/R680M IGPU (Yellow Carp)).

I have found the CPU ID for Ryzen 7 6800H Laptop CPU - Rembrandt (0x44) at:
https://github.com/irusanov/ZenStates-Core/blob/master/Cpu.cs

The power statistic seem to work and also MangoHud git branch works.
This is the only way atm for the CPU power to work with MangoHUD with Rembrandt.

Thank You for your great effort.

Example output of  **sensors**:

```
zenergy-isa-0000
Adapter: ISA adapter
Ecore000:      2.12 kJ
Ecore001:      2.12 kJ
Ecore002:      2.26 kJ
Ecore003:      2.26 kJ
Ecore004:      2.11 kJ
Ecore005:      2.11 kJ
Ecore006:      2.02 kJ
Ecore007:      2.02 kJ
Esocket0:    114.15 kJ
```
